### PR TITLE
Restructure Redux Store

### DIFF
--- a/src/main/views/CreateTestTemplatePage.js
+++ b/src/main/views/CreateTestTemplatePage.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { Form, Input, PageHeader, Button } from 'antd';
 
 import Page from '../../common/views/Page';
-import WebApi from '../utils/webApi';
+import Test from '../../model/test';
 
 const layout = {
   labelCol: {
@@ -38,17 +37,20 @@ class CreateTestTemplatePage extends Component {
     console.log('Success:', values);
     this.setState({loading: true});
     const { name, jobname, group, frequency, duration, httpmethod, httpurl } = values;
-    const response = await WebApi.createTest(name, [
-      {
-        Name: jobname,
-        Group: group,
-        Priority: 0,
-        Frequency: parseInt(frequency),
-        Duration: parseInt(duration),
-        HTTPMethod: httpmethod,
-        HTTPUrl: httpurl,
-      }
-    ]);
+    const response = await Test.create({
+      Name: name,
+      Jobs: [
+        {
+          Name: jobname,
+          Group: group,
+          Priority: 0,
+          Frequency: parseInt(frequency),
+          Duration: parseInt(duration),
+          HTTPMethod: httpmethod,
+          HTTPUrl: httpurl,
+        },
+      ],
+    });
     console.log(response);
     this.setState({loading: false});
     // TODO: show success banner

--- a/src/main/views/index.js
+++ b/src/main/views/index.js
@@ -1,21 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
 import { PageHeader, Button } from 'antd';
 
 import Page from '../../common/views/Page';
 import MainPageContent from './MainPageContent';
-import { getTest } from '../actions';
 
-class MainPage extends Component {
+export default class MainPage extends Component {
   goToCreateTestTemplatePage = () => {
     const { history, location } = this.props;
     history.push('create-test-template', {from: location.pathname});
   }
 
   render() {
-    const { getTest, testTemplate, history, location } = this.props;
+    const { history, location } = this.props;
     return (
       <Page
         CustomPageHeader={
@@ -35,8 +32,6 @@ class MainPage extends Component {
           <MainPageContent
             history={history}
             location={location}
-            getTest={getTest} 
-            testTemplate={testTemplate}
           />
         }
       />
@@ -47,16 +42,4 @@ class MainPage extends Component {
 MainPage.propTypes = {
   history: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
-  getTest: PropTypes.func.isRequired,
-  testTemplate: PropTypes.object,
 };
-
-const mapStateToProps = ({ mainPageReducer }) => ({
-  testTemplate: mainPageReducer.testTemplate,
-});
-
-const mapDispatchToProps = dispatch => bindActionCreators({
-  getTest: getTest,
-}, dispatch);
-
-export default connect(mapStateToProps, mapDispatchToProps)(MainPage);

--- a/src/model/actions.js
+++ b/src/model/actions.js
@@ -1,0 +1,2 @@
+export const RECEIVE_DOCUMENTS = 'receive_documents'
+export const DELETE_DOCUMENT = 'delete_document';

--- a/src/model/client.js
+++ b/src/model/client.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+class Client {
+  BASE_URL = '/api';
+  get = path => axios.get(`${this.BASE_URL}/${path}`);
+  post = (path, data) => axios.post(`${this.BASE_URL}/${path}`, data);
+  delete = path => axios.delete(`${this.BASE_URL}/${path}`);
+}
+
+let client;
+const getClient = () => {
+  if (!client) {
+    client = new Client();
+  }
+  return client;
+};
+
+export default getClient;

--- a/src/model/document.js
+++ b/src/model/document.js
@@ -1,0 +1,43 @@
+import getClient from './client';
+import store from '../store';
+import { RECEIVE_DOCUMENTS } from './actions';
+
+export default class Document {
+  constructor(obj) {
+    Object.assign(this, obj);
+  }
+
+  static BASE_URL() {
+    return '/api';
+  }
+
+  static docName() {
+    throw new Error('A model class must implement `docName()`');
+  }
+
+  static async get(id) {
+    const response = await getClient().get(`${this.docName()}/${id}`);
+    if (response.data?.success) {
+      const doc = new this(response.data?.payload);
+      store.dispatch({
+        type: RECEIVE_DOCUMENTS,
+        data: {
+          docs: [doc],
+          docType: this.docName(),
+        },
+      })
+      return Object.assign(response, { doc })
+    }
+    return response;
+  }
+
+  static async create(data) {
+    const response = await getClient().post(`${this.docName()}`, data);
+    return response;
+  }
+
+  static async delete() {
+    const response = await getClient().delete(`${this.docName()}/${this.id}`);
+    return response;
+  }
+}

--- a/src/model/reducer.js
+++ b/src/model/reducer.js
@@ -1,0 +1,16 @@
+import { RECEIVE_DOCUMENTS } from './actions';
+
+const reduceDocs = (state={}, action) => {
+  switch(action.type) {
+    case RECEIVE_DOCUMENTS:
+      const { docType, docs } = action.data;
+      return {
+        ...state,
+        [docType]: new Map([...(state[docType] || new Map()), ...docs.map(doc => [doc.ID, doc])]),
+      };
+    default:
+      return state;
+  }
+}
+
+export default reduceDocs;

--- a/src/model/test-instance.js
+++ b/src/model/test-instance.js
@@ -1,0 +1,26 @@
+import Document from './document';
+import getClient from './client';
+import store from '../store';
+import { RECEIVE_DOCUMENTS } from './actions';
+
+export default class TestInstance extends Document {
+  static docName() {
+    return 'test-instances';
+  }
+
+  static async forTestId(testId) {
+    const response = await getClient().get(`${this.docName()}/${testId}`);
+    if (response.data?.success) {
+      const docs = response.data?.payload.map(raw => new this(raw));
+      store.dispatch({
+        type: RECEIVE_DOCUMENTS,
+        data: {
+          docs,
+          docType: this.docName(),
+        },
+      })
+      return Object.assign(response, { docs })
+    }
+    return response;
+  }
+}

--- a/src/model/test.js
+++ b/src/model/test.js
@@ -1,0 +1,13 @@
+import Document from './document';
+import getClient from './client';
+
+export default class Test extends Document {
+  static docName() {
+    return 'tests';
+  }
+
+  async start() {
+    const response = getClient().get(`start-test/${this.ID}`);
+    return response;
+  }
+}

--- a/src/store.js
+++ b/src/store.js
@@ -8,10 +8,12 @@ import thunk from 'redux-thunk';
 
 import mainPageReducer from './main/reducer';
 import testTemplateDetailsPageReducer from './test-template-details/reducer';
+import modelReducer from './model/reducer';
 
 const rootReducer = combineReducers({
     mainPageReducer,
     testTemplateDetailsPageReducer,
+    model: modelReducer,
 });
 
 const persistedState = {};


### PR DESCRIPTION
Restructure the redux store so we can use a generic action, `RECEIVE_DOCUMENTS`, and a single reducer to create model class objects for every type of document.

Individual documents are accessible by `state.model.<document-name>.get(<id>)`.

We can probably rm `webApi.js`, `actions.js`, and `reducer.js` from every other subdirectory.